### PR TITLE
Escape parentheses in links

### DIFF
--- a/redditbot.py
+++ b/redditbot.py
@@ -77,7 +77,7 @@ def build_reply(text):
         if link is None: continue
         page = get_page(link)
         if page is None: continue
-        reply += "[%s](%s)\n\n" % (name, link)
+        reply += "[%s](%s)\n\n" % (name, link.replace("(", "\\(").replace(")", "\\)"))
         reply += ip.parse_item(page)
     if reply is "": 
         return None        


### PR DESCRIPTION
Unescaped parentheses in links break reddit's formatting, so add two .replace() calls to escape them all. [Example](https://www.reddit.com/r/pathofexile/comments/5cqnan/is_it_possible_to_oneshot_myself_to_reflect_with/d9yl0p3/)

Also, that comment produced a name but no item panel, not looked into why yet.