### PR TITLE
Fix Doryani's Invitation variants not being found

### DIFF
--- a/redditbot.py
+++ b/redditbot.py
@@ -108,8 +108,8 @@ def get_page(link):
 # E.g. input "Vessel of Vinktar" may return "Vessel of Vinktar (Added Lightning Damage to Attacks)",
 # since there are several versions of Vessel of Vinktar. 
 def get_item_panel(name):
-    name = urllib2.quote(name)
-    url = "https://pathofexile.gamepedia.com/api.php?action=askargs&conditions=Has%%20name::%s&printouts=Has%%20infobox%%20HTML&format=json" % name
+    name = urllib2.quote(name.replace(" ", "_")
+    url = "https://pathofexile.gamepedia.com/api.php?action=askargs&conditions=%s&printouts=Has%%20infobox%%20HTML&format=json" % name
     response = get_page(url)
     jsonData = json.loads(response)
     if "query" not in jsonData:


### PR DESCRIPTION
[I've just tested this manually by copy-pasting my new link and adding the name in](https://pathofexile.gamepedia.com/api.php?action=askargs&conditions=Doryani%27s_Invitation_(Cold_Damage)&printouts=Has%20infobox%20HTML&format=json). It returns the infobox for Doryani's Invitation cold variant, and also Woodsplitter and The Dark Seer (two random others I tried with).

I haven't tested the code itself though, and I haven't done much unique testing (this would be easier with the code compiled).