### PR TITLE
Fix ignore list check

### DIFF
--- a/redditbot.py
+++ b/redditbot.py
@@ -21,8 +21,8 @@ def is_parsed(comment_id):
 def add_parsed(comment_id):
     return redis.sadd("parsed_comments", comment_id)
 
-def is_ignored(username):
-    return username in ignore_list
+def is_ignored(user):
+    return user.name in ignore_list
 
 def bot_comments():
     sub_comments = subreddit.comments()


### PR DESCRIPTION
I adjusted the format of PoBPreviewBot's comments and now PoEWikiBot is responding to it with a link to Tree hideout decorations.

https://www.reddit.com/r/pathofexile/comments/bttmn9/legion_league_faq/ep2l7hr/

(also somebody gilded you for it lol)

I poked around in the code, it looks like the username parameter of is_ignored is being passed a `praw.models.Redditor` not a `str`, so comparing it to the list of strs parsed from the ignore file will always return false. Not sure whether `Redditor.name` will return `/u/aggixx` or just `aggixx` so that might need to be checked to make sure it works. (Or change the ignore list format).